### PR TITLE
fix: Use Vite plugin from `@testing-library/svelte` instead of manual config

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
 		"src"
 	],
 	"scripts": {
-		"lint": "prettier --check '**/*' --ignore-unknown && eslint . && svelte-check --tsconfig ./tsconfig.json && vitest",
-		"format": "prettier --write '**/*' --ignore-unknown",
+		"lint": "prettier --check . --ignore-unknown && eslint . && svelte-check --tsconfig ./tsconfig.json && vitest",
+		"format": "prettier --write . --ignore-unknown",
 		"build": "svelte-package --input ./src && publint --strict"
 	},
 	"devDependencies": {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,6 +1,1 @@
 import "@testing-library/jest-dom/vitest";
-import { cleanup } from "@testing-library/svelte";
-import { afterEach } from "vitest";
-
-// https://testing-library.com/docs/svelte-testing-library/api/#cleanup
-afterEach(() => cleanup());

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,9 @@
 import { defineConfig } from "vitest/config";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
+import { svelteTesting } from "@testing-library/svelte/vite";
 
 export default defineConfig({
-	plugins: [svelte()],
+	plugins: [svelte(), svelteTesting()],
 	test: {
 		watch: false,
 		include: ["tests/**/*.{test,spec}.{js,ts}"],


### PR DESCRIPTION
See step 3 from: https://testing-library.com/docs/svelte-testing-library/setup#vitest

- Added `svelteTesting()` Vite plugin exported from `@testing-library/svelte`
- Changed `**/*` to `.` as it's identical and `**/*` doesn't work (on windows).